### PR TITLE
Add GUI for Analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Tool around fetching and computing information on the status of currency networks as a graph and their users.
 
-
 ## Installation
 
 The network analyzer tool requires python 3.8 or up. You can install its requirements from this repository with
@@ -29,4 +28,22 @@ Options:
   --relay URL    Relay API URL  [default: http://localhost:5000/api/v1]
   --output PATH  Path of the directory to output the csv to
   --help         Show this message and exit.
+```
+
+## GUI version
+
+You can generate a GUI executable for different OS (Windows, Mac) using Python lib `PyInstaller`. `./src/network_analyzer/app.py` is a sample script for generating a simple GUI that gives you the option to choose the RPC and Relay servers, and the folder you would like the analysis files to be generated. So, easily you can follow those steps to generate an executable:
+
+```
+$ pip install pyinstaller
+$ cd src/network_analyzer
+$ pyinstaller app.py -y
+```
+
+This should generate the executable with some other files by default at `./src/network_analyzer/dist/app`, and you need then to copy `contracts.json` to `dist/app/network_analyzer/contracts.json`
+
+```
+-- bash shell
+$ mkdir ./dist/app/network_analyzer && \
+  cp contracts.json ./dist/app/network_analyzer
 ```

--- a/src/network_analyzer/analyzer.py
+++ b/src/network_analyzer/analyzer.py
@@ -112,6 +112,7 @@ class Analyzer:
                 network_information_dictionary=info_dictionary,
                 user_dictionaries=user_dictionaries,
                 transfer_dictionaries=transfer_dictionaries,
+                output_path=self.output_path,
             )
 
     def request_relay_api(self, endpoint):

--- a/src/network_analyzer/app.py
+++ b/src/network_analyzer/app.py
@@ -5,8 +5,7 @@ from network_analyzer.analyzer import Analyzer
 # Analyzer
 csv_dir_path = None
 default_jsonrpc = "https://tlbc.rpc.anyblock.tools"
-default_relay_api_url = "https://tlbc.relay.anyblock.tools/api/v1"
-# default_relay_api_url = "http://localhost:5000/api/v1"
+default_relay_api_url = "http://localhost:5000/api/v1"
 
 # App main window
 root = tk.Tk()

--- a/src/network_analyzer/app.py
+++ b/src/network_analyzer/app.py
@@ -1,0 +1,52 @@
+import tkinter as tk
+from tkinter import filedialog
+from network_analyzer.analyzer import Analyzer
+
+# Analyzer
+csv_dir_path = None
+default_jsonrpc = "https://tlbc.rpc.anyblock.tools"
+default_relay_api_url = "https://tlbc.relay.anyblock.tools/api/v1"
+# default_relay_api_url = "http://localhost:5000/api/v1"
+
+# App main window
+root = tk.Tk()
+
+root.title("Trustlines Network Analyzer")
+root.geometry("500x250")
+
+canvas_window = tk.Canvas(root, width=300, height=300)
+canvas_window.pack()
+
+jsonrpc = tk.StringVar(root, default_jsonrpc)
+relay = tk.StringVar(root, default_relay_api_url)
+
+label_jsonrpc = tk.Label(root, text="JSON RPC URL").place(x=30, y=50)
+text_jsonrpc = tk.Entry(root, textvariable=jsonrpc, width=30).place(x=180, y=50)
+
+label_relay = tk.Label(root, text="Relay API Server URL").place(x=30, y=90)
+text_relay = tk.Entry(root, textvariable=relay, width=30).place(x=180, y=90)
+label_chosen_path = tk.Label(root, text="")
+
+
+def choose_folder():
+    global csv_dir_path
+    csv_dir_path = filedialog.askdirectory()
+    label_chosen_path.config(text=csv_dir_path)
+
+
+label_folder_csv = tk.Label(root, text="Save Files to").place(x=30, y=130)
+button_folder_csv = tk.Button(root, text="Browse Folders", command=choose_folder).place(x=180, y=130)
+label_chosen_path.place(x=180, y=170)
+
+
+def analyze():
+    analyzer = Analyzer(jsonrpc=jsonrpc.get(), relay_api_url=relay.get(), output_path=csv_dir_path)
+    analyzer.analyze_bridge_transfers()
+    analyzer.analyze_networks()
+    analyzer.analyze_dead_identities()
+
+
+button_analyze = tk.Button(text='Analyze', command=analyze, bg='green', fg='white')
+canvas_window.create_window(170, 210, window=button_analyze)
+
+root.mainloop()


### PR DESCRIPTION
Using PyInstaller package, developer can generate a simple GUI for the  
network analyzer. The GUI gives the user the ability to choose the relay  
and the rpc servers for generating the data, and the folder at which the  
csv data files are going to be generated.  
For building the app, just run `pyinstaller app.py -y`, this will  
generate the executable and other files at `./dist/app`, and then  
you will need to maually copy `contracts.json` to  
`./dist/app/network_analyzer/contracts.json`.  
Worths mentioning that `PyInstaller` generates the executable for  
the environment it runs on (generates .exex on a Windows machine  
and mac executable on Mac). Also, there are limitations on Mac  
machine for the specific OS version. PyInstaller is stupid enough to  
force you to make a run on each MacOS version you want the app to run on